### PR TITLE
Fixes #1 - Allow code to build for Swift compilers <5.5

### DIFF
--- a/Tests/LoggingTests/Test+Floats.swift
+++ b/Tests/LoggingTests/Test+Floats.swift
@@ -19,7 +19,11 @@ final class FloatTests: XCTestCase {
         logger.debug("\(max, privacy: .public)")
         XCTAssertEqual(logging.recorder.message, "\(CGFloat.greatestFiniteMagnitude)")
 
+        #if swift(<5.5)
+        logger.debug("\(Float(value), format: .fixed(precision: 2), privacy: .public)")
+        #else
         logger.debug("\(value, format: .fixed(precision: 2), privacy: .public)")
+        #endif
         XCTAssertEqual(logging.recorder.message, "3.14")
     }
 


### PR DESCRIPTION
Interchangable use of CGFloat and Double isn't supported until Swift 5.5:

https://github.com/apple/swift-evolution/blob/main/proposals/0307-allow-interchangeable-use-of-double-cgfloat-types.md

Addes #if swift(<5.5) conditional to allow compiling in older Swift versions.

Note: Only ran the tests on macOS 11.5.2.
All Test+Float tests pass in Swift 5.4.2 with this change, and it compiles in both 5.4.2 and 5.5, but there's a test assertion failure in Swift 5.5 (release version with Xcode 13.0).  That's a separate issue.

Fix for issue #1 

Added conditional test for swift version and construct a `Double` manually on swift compiler versions less than 5.5.

Note: This PR doesn’t address project’s other failing tests in Test+Private.swift in Swift 5.5 and 5.4.2 even with this fix. Those filed as #2