### PR TITLE
Better fix for Issue #1 support for Swift compiler < 5.5

### DIFF
--- a/Sources/Logging/Interpolation.swift
+++ b/Sources/Logging/Interpolation.swift
@@ -9,6 +9,7 @@ import Foundation
         case signedInt(() -> Int64, format: LogIntegerFormatting, alignment: LogStringAlignment, privacy: LogPrivacy)
         case unsignedInt(() -> UInt64, format: LogIntegerFormatting, alignment: LogStringAlignment, privacy: LogPrivacy)
         case float(() -> Float, format: LogFloatFormatting, alignment: LogStringAlignment, privacy: LogPrivacy)
+		case cgfloat(() -> CGFloat, format: LogFloatFormatting, alignment: LogStringAlignment, privacy: LogPrivacy)
         case double(() -> Double, format: LogFloatFormatting, alignment: LogStringAlignment, privacy: LogPrivacy)
         case bool(() -> Bool, format: LogBoolFormat, privacy: LogPrivacy)
         case object(() -> NSObject, privacy: LogPrivacy)
@@ -67,6 +68,11 @@ extension LogInterpolation {
     public mutating func appendInterpolation(_ number: @autoclosure @escaping () -> Float, format: LogFloatFormatting = .fixed, align: LogStringAlignment = .none, privacy: LogPrivacy = .private) {
         storage.append(.float(number, format: format, alignment: align, privacy: privacy))
     }
+
+	/// Defines interpolation for expressions of type CGFloat
+	public mutating func appendInterpolation(_ number: @autoclosure @escaping () -> CGFloat, format: LogFloatFormatting = .fixed, align: LogStringAlignment = .none, privacy: LogPrivacy = .private) {
+		storage.append(.cgfloat(number, format: format, alignment: align, privacy: privacy))
+	}
 
     /// Defines interpolation for expressions of type Double
     public mutating func appendInterpolation(_ number: @autoclosure @escaping () -> Double, format: LogFloatFormatting = .fixed, align: LogStringAlignment = .none, privacy: LogPrivacy = .private) {

--- a/Sources/Logging/Interpolation.swift
+++ b/Sources/Logging/Interpolation.swift
@@ -9,7 +9,7 @@ import Foundation
         case signedInt(() -> Int64, format: LogIntegerFormatting, alignment: LogStringAlignment, privacy: LogPrivacy)
         case unsignedInt(() -> UInt64, format: LogIntegerFormatting, alignment: LogStringAlignment, privacy: LogPrivacy)
         case float(() -> Float, format: LogFloatFormatting, alignment: LogStringAlignment, privacy: LogPrivacy)
-		case cgfloat(() -> CGFloat, format: LogFloatFormatting, alignment: LogStringAlignment, privacy: LogPrivacy)
+        case cgfloat(() -> CGFloat, format: LogFloatFormatting, alignment: LogStringAlignment, privacy: LogPrivacy)
         case double(() -> Double, format: LogFloatFormatting, alignment: LogStringAlignment, privacy: LogPrivacy)
         case bool(() -> Bool, format: LogBoolFormat, privacy: LogPrivacy)
         case object(() -> NSObject, privacy: LogPrivacy)
@@ -69,10 +69,10 @@ extension LogInterpolation {
         storage.append(.float(number, format: format, alignment: align, privacy: privacy))
     }
 
-	/// Defines interpolation for expressions of type CGFloat
-	public mutating func appendInterpolation(_ number: @autoclosure @escaping () -> CGFloat, format: LogFloatFormatting = .fixed, align: LogStringAlignment = .none, privacy: LogPrivacy = .private) {
-		storage.append(.cgfloat(number, format: format, alignment: align, privacy: privacy))
-	}
+    /// Defines interpolation for expressions of type CGFloat
+    public mutating func appendInterpolation(_ number: @autoclosure @escaping () -> CGFloat, format: LogFloatFormatting = .fixed, align: LogStringAlignment = .none, privacy: LogPrivacy = .private) {
+        storage.append(.cgfloat(number, format: format, alignment: align, privacy: privacy))
+    }
 
     /// Defines interpolation for expressions of type Double
     public mutating func appendInterpolation(_ number: @autoclosure @escaping () -> Double, format: LogFloatFormatting = .fixed, align: LogStringAlignment = .none, privacy: LogPrivacy = .private) {

--- a/Sources/Logging/Message.swift
+++ b/Sources/Logging/Message.swift
@@ -43,6 +43,13 @@ extension Logger {
                         let string = String(format: "\(explicitPositiveSign ? "+" : "")%.0\(precision())f", value)
                         message.append(privacy.value(for: string))
                     }
+				case let .cgfloat(value, format, _, privacy):
+					switch format.format {
+					case let .fixed(precision, explicitPositiveSign):
+						let value = value()
+						let string = String(format: "\(explicitPositiveSign ? "+" : "")%.0\(precision())f", value)
+						message.append(privacy.value(for: string))
+					}
                 case let .signedInt(value, format, _, privacy):
                     switch format.format {
                     case let .decimal(minDigits, explicitPositiveSign):
@@ -62,8 +69,8 @@ extension Logger {
                     message.append(privacy.value(for: value()))
                 case let .string(value, _, privacy):
                     message.append(privacy.value(for: value()))
-                }
-            }
+				}
+			}
 
             return message
         }

--- a/Sources/Logging/Message.swift
+++ b/Sources/Logging/Message.swift
@@ -43,13 +43,13 @@ extension Logger {
                         let string = String(format: "\(explicitPositiveSign ? "+" : "")%.0\(precision())f", value)
                         message.append(privacy.value(for: string))
                     }
-				case let .cgfloat(value, format, _, privacy):
-					switch format.format {
-					case let .fixed(precision, explicitPositiveSign):
-						let value = value()
-						let string = String(format: "\(explicitPositiveSign ? "+" : "")%.0\(precision())f", value)
-						message.append(privacy.value(for: string))
-					}
+                case let .cgfloat(value, format, _, privacy):
+                    switch format.format {
+                    case let .fixed(precision, explicitPositiveSign):
+                        let value = value()
+                        let string = String(format: "\(explicitPositiveSign ? "+" : "")%.0\(precision())f", value)
+                        message.append(privacy.value(for: string))
+                    }
                 case let .signedInt(value, format, _, privacy):
                     switch format.format {
                     case let .decimal(minDigits, explicitPositiveSign):
@@ -69,8 +69,8 @@ extension Logger {
                     message.append(privacy.value(for: value()))
                 case let .string(value, _, privacy):
                     message.append(privacy.value(for: value()))
-				}
-			}
+                }
+            }
 
             return message
         }

--- a/Tests/LoggingTests/Test+Floats.swift
+++ b/Tests/LoggingTests/Test+Floats.swift
@@ -14,10 +14,10 @@ final class FloatTests: XCTestCase {
         logger.logLevel = .trace
 
         logger.debug("\(min, privacy: .public)")
-        XCTAssertEqual(logging.recorder.message, "\(CGFloat.leastNonzeroMagnitude)")
+        XCTAssertEqual(logging.recorder.message, String(format: "%.06f", CGFloat.leastNonzeroMagnitude))
 
         logger.debug("\(max, privacy: .public)")
-        XCTAssertEqual(logging.recorder.message, "\(CGFloat.greatestFiniteMagnitude)")
+		XCTAssertEqual(logging.recorder.message, String(format: "%.06f", CGFloat.greatestFiniteMagnitude))
 
         logger.debug("\(value, format: .fixed(precision: 2), privacy: .public)")
         XCTAssertEqual(logging.recorder.message, "3.14")

--- a/Tests/LoggingTests/Test+Floats.swift
+++ b/Tests/LoggingTests/Test+Floats.swift
@@ -17,7 +17,7 @@ final class FloatTests: XCTestCase {
         XCTAssertEqual(logging.recorder.message, String(format: "%.06f", CGFloat.leastNonzeroMagnitude))
 
         logger.debug("\(max, privacy: .public)")
-		XCTAssertEqual(logging.recorder.message, String(format: "%.06f", CGFloat.greatestFiniteMagnitude))
+        XCTAssertEqual(logging.recorder.message, String(format: "%.06f", CGFloat.greatestFiniteMagnitude))
 
         logger.debug("\(value, format: .fixed(precision: 2), privacy: .public)")
         XCTAssertEqual(logging.recorder.message, "3.14")


### PR DESCRIPTION
More complete fix for Issue #1.  Note commit comment about not including #if swift(<5.5) as a personal preference that you’re free to add if you prefer it be there.