### PR TITLE
Help new to the project person understand why tests are failing & what fix is

### DIFF
--- a/Tests/LoggingTests/Test+Private.swift
+++ b/Tests/LoggingTests/Test+Private.swift
@@ -5,8 +5,9 @@ final class PrivateTests: XCTestCase {
 
     func testPrivate() {
         #if DEBUG
-        XCTFail("\n\n   *** Tests for Redaction must be run in release build.  Use `swift test -c release` from the command line.\n")
-        #endif
+        print("\n\n   *** Tests for Redaction skipped! ***  ")
+        print("           They require release build; use `swift test -c release` from command line.\n")
+        #else
         
         let signed = -3.14159265359
         let unsigned = 3.14
@@ -61,6 +62,7 @@ final class PrivateTests: XCTestCase {
         XCTAssertEqual(logging.recorder.message, LogPrivacy.redacted)
         logger.debug("\(UInt(unsigned), format: .decimal(explicitPositiveSign: true, minDigits: 0))")
         XCTAssertEqual(logging.recorder.message, LogPrivacy.redacted)
+        #endif
     }
 
 }

--- a/Tests/LoggingTests/Test+Private.swift
+++ b/Tests/LoggingTests/Test+Private.swift
@@ -4,6 +4,10 @@ import XCTest
 final class PrivateTests: XCTestCase {
 
     func testPrivate() {
+        #if DEBUG
+        XCTFail("\n\n   *** Tests for Redaction must be run in release build.  Use `swift test -c release` from the command line.\n")
+        #endif
+        
         let signed = -3.14159265359
         let unsigned = 3.14
         let logging = TestLogging()


### PR DESCRIPTION
Issue #2 

## Describe your changes

Since it's relatively unusual that testing must be done with a release build add a message with help for a new-to-the-project person to understand what they need to do to make tests run.

Originally I had this just an `XCTFail("…")` message and let the rest of the asserts fail also, but decided it might be better to make the test _not_ fail in debug builds because most projects that depend upon this will likely not want to run their automated testing on release builds so if they incorporate this package it'll break their automated builds.  I can revert this last commit to make the PR from the previous commit if you prefer it breaking from the command line.
