### PR TITLE
fix #2 via a property settable in tests.

### DIFF
--- a/.swiftpm/xcode/xcshareddata/xcschemes/Logging.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/Logging.xcscheme
@@ -23,7 +23,7 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
-      buildConfiguration = "Release"
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"

--- a/Sources/Logging/Interpolation.swift
+++ b/Sources/Logging/Interpolation.swift
@@ -183,8 +183,8 @@ public struct LogIntegerFormatting {
 
     internal static let redacted = "<redacted>"
     internal func value(for value: Any) -> String {
-        #if DEBUGGING
-        if disableRedaction {
+        #if DEBUG
+        if LogPrivacy.disableRedaction {
             return String(describing: value)
         }
         #endif

--- a/Sources/Logging/Interpolation.swift
+++ b/Sources/Logging/Interpolation.swift
@@ -177,11 +177,17 @@ public struct LogIntegerFormatting {
         LogPrivacy(isPrivate: true, mask: mask)
     }
 
+    #if DEBUG
+    internal static var disableRedaction: Bool = true
+    #endif
+
     internal static let redacted = "<redacted>"
     internal func value(for value: Any) -> String {
-        #if DEBUG
-        return String(describing: value)
-        #else
+        #if DEBUGGING
+        if disableRedaction {
+            return String(describing: value)
+        }
+        #endif
 
         switch self {
         case .public:
@@ -191,6 +197,5 @@ public struct LogIntegerFormatting {
         default:
             return Self.redacted
         }
-        #endif
     }
 }

--- a/Tests/LoggingTests/Test+Private.swift
+++ b/Tests/LoggingTests/Test+Private.swift
@@ -6,6 +6,9 @@ final class PrivateTests: XCTestCase {
     func testPrivate() {
         let signed = -3.14159265359
         let unsigned = 3.14
+        #if DEBUG
+        LogPrivacy.disableRedaction = false
+        #endif
         let logging = TestLogging()
         LoggingSystem.bootstrapInternal(logging.make)
 


### PR DESCRIPTION
Issue #2 

## Describe your changes

From the commit:  Alternate method of fixing this issue which allows tests to run in both Release or Debug configurations via a new DEBUG build only configuration variable in `LogPrivacy` which may be set in tests.